### PR TITLE
Add basic TypeScript Next.js API with Swagger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+.env*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# new
+# Data Library API
+
+This project is a simple Next.js application written in TypeScript and styled with Tailwind CSS. It exposes an API for storing arbitrary data objects in an in-memory store and provides Swagger documentation.
+
+## Features
+
+- **Next.js & React** – Application and API routes.
+- **TypeScript** – Static type checking.
+- **Tailwind CSS** – Utility-first styling.
+- **Swagger UI** – Documentation available at `/api-docs`.
+
+## Available Scripts
+
+- `npm run dev` – Start the development server.
+- `npm run build` – Build the application for production.
+- `npm start` – Start the production server.
+
+The API endpoint `/api/library` supports `GET` and `POST` requests. `POST` accepts a JSON body with `id`, `type`, and `payload` fields and stores the record in memory.

--- a/lib/dataStore.ts
+++ b/lib/dataStore.ts
@@ -1,0 +1,22 @@
+export type StoredRecord = {
+  id: string;
+  type: string;
+  payload: any;
+  receivedAt: number;
+};
+
+class DataStore {
+  private records: StoredRecord[] = [];
+
+  add(record: Omit<StoredRecord, 'receivedAt'>) {
+    const entry: StoredRecord = { ...record, receivedAt: Date.now() };
+    this.records.push(entry);
+    return entry;
+  }
+
+  list() {
+    return this.records;
+  }
+}
+
+export const store = new DataStore();

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "data-library-api",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "next": "^13.5.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "swagger-jsdoc": "^7.0.0",
+    "swagger-ui-express": "^4.6.3",
+    "next-swagger-doc": "^0.0.4",
+    "swagger-ui-react": "^4.15.5"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/node": "^18.0.0",
+    "@types/react": "^18.0.0",
+    "@types/swagger-jsdoc": "^6.0.0",
+    "@types/swagger-ui-express": "^4.1.3",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/pages/api-docs.tsx
+++ b/pages/api-docs.tsx
@@ -1,0 +1,10 @@
+import SwaggerUI from 'swagger-ui-react';
+import 'swagger-ui-react/swagger-ui.css';
+
+const ApiDocs = () => {
+  return (
+    <SwaggerUI url="/api/docs" />
+  );
+};
+
+export default ApiDocs;

--- a/pages/api/docs.ts
+++ b/pages/api/docs.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createSwaggerSpec } from 'next-swagger-doc';
+
+export const getSwaggerSpec = () => createSwaggerSpec({
+  apiFolder: 'pages/api',
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'Data Library API',
+      version: '1.0.0',
+    },
+  },
+});
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const spec = getSwaggerSpec();
+  res.status(200).json(spec);
+}

--- a/pages/api/library.ts
+++ b/pages/api/library.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { store, StoredRecord } from '../../lib/dataStore';
+
+/**
+ * @swagger
+ * /api/library:
+ *   get:
+ *     description: List all stored records.
+ *     responses:
+ *       200:
+ *         description: Array of stored records
+ *   post:
+ *     description: Store a new record. Accepts JSON payload.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               id:
+ *                 type: string
+ *               type:
+ *                 type: string
+ *               payload:
+ *                 type: object
+ *     responses:
+ *       200:
+ *         description: Stored record
+ */
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    const { id, type, payload } = req.body as Omit<StoredRecord, 'receivedAt'>;
+    if (!id || !type) {
+      return res.status(400).json({ message: 'id and type are required' });
+    }
+    const entry = store.add({ id, type, payload });
+    return res.status(200).json(entry);
+  }
+
+  if (req.method === 'GET') {
+    return res.status(200).json(store.list());
+  }
+
+  res.setHeader('Allow', ['GET', 'POST']);
+  res.status(405).end(`Method ${req.method} Not Allowed`);
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,13 @@
+import type { NextPage } from 'next'
+
+const Home: NextPage = () => {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Data Library API</h1>
+      <p className="mt-2">Welcome to the Data Library API built with Next.js and TypeScript.</p>
+      <p className="mt-2">Visit <a className="text-blue-500 underline" href="/api/docs">/api/docs</a> for Swagger documentation.</p>
+    </div>
+  )
+}
+
+export default Home

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize Next.js + TypeScript project
- add Tailwind and config files
- implement in-memory data store
- create `/api/library` endpoint with Swagger docs
- expose swagger spec and UI at `/api/docs` and `/api-docs`
- document usage in README

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425cec59b483309bb2a98aec9be970