### PR TITLE
Remove swagger dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,6 @@
     "next": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "swagger-jsdoc": "^7.0.0",
-    "swagger-ui-express": "^4.6.3",
     "next-swagger-doc": "^0.0.4",
     "swagger-ui-react": "^4.15.5",
     "pg": "^8.11.3"
@@ -23,8 +21,6 @@
     "typescript": "^5.0.0",
     "@types/node": "^18.0.0",
     "@types/react": "^18.0.0",
-    "@types/swagger-jsdoc": "^6.0.0",
-    "@types/swagger-ui-express": "^4.1.3",
     "tailwindcss": "^3.3.0",
     "postcss": "^8.4.0",
     "autoprefixer": "^10.4.0"


### PR DESCRIPTION
## Summary
- remove `swagger-jsdoc` and `swagger-ui-express`
- clean up dev dependency typings

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6842635357308330a8a7190923ec81e3