### PR TITLE
Fix build errors by avoiding server import of Swagger UI

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,11 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  webpack: (config) => {
+    // Fix build error caused by directory import in swagger-ui-react
+    config.resolve.alias['remarkable/linkify'] = 'remarkable/dist/cjs/linkify.js';
+    return config;
+  },
 };
 
 module.exports = nextConfig;

--- a/pages/api-docs.tsx
+++ b/pages/api-docs.tsx
@@ -1,5 +1,8 @@
-import SwaggerUI from 'swagger-ui-react';
+import dynamic from 'next/dynamic';
 import 'swagger-ui-react/swagger-ui.css';
+
+// Dynamically import swagger-ui-react to avoid server-side build issues
+const SwaggerUI = dynamic(() => import('swagger-ui-react'), { ssr: false });
 
 const ApiDocs = () => {
   return (


### PR DESCRIPTION
## Summary
- fix swagger-ui-react import by using dynamic import with no SSR
- alias `remarkable/linkify` in webpack config to prevent unsupported directory import error

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684267fb49408330af2d042ce51a4526