### PR TITLE
Improve outcomes UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Data Library API
 
-This project is a simple Next.js application written in TypeScript and styled with Tailwind CSS. It exposes an API for storing arbitrary data objects in a PostgreSQL database (tested with Neon) and provides Swagger documentation. A small web UI lets you manage and export stored outcomes.
+This project is a simple Next.js application written in TypeScript and styled with Tailwind CSS. It exposes an API for storing arbitrary data objects in a PostgreSQL database (tested with Neon) and provides Swagger documentation. A small, responsive web UI lets you manage and export stored outcomes.
 
 ## Features
 

--- a/components/RecordCard.tsx
+++ b/components/RecordCard.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+
+interface RecordCardProps {
+  record: { id: string; type: string; payload: any };
+  onCopy: (payload: any) => void;
+  onDelete: (id: string) => void;
+  onUpdate: (id: string, payload: any) => void;
+}
+
+export default function RecordCard({
+  record,
+  onCopy,
+  onDelete,
+  onUpdate,
+}: RecordCardProps) {
+  const initial =
+    typeof record.payload === "string"
+      ? record.payload
+      : JSON.stringify(record.payload, null, 2);
+  const [value, setValue] = useState(initial);
+
+  const handleSave = () => {
+    onUpdate(record.id, value);
+  };
+
+  return (
+    <div className="border rounded shadow-sm p-4 bg-white">
+      <div className="flex justify-between items-center mb-2">
+        <h2 className="font-semibold text-lg">{record.id}</h2>
+        <div className="space-x-3 text-sm">
+          <button
+            className="text-blue-600 hover:underline"
+            onClick={() => onCopy(record.payload)}
+          >
+            Copy
+          </button>
+          <button
+            className="text-red-600 hover:underline"
+            onClick={() => onDelete(record.id)}
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+      <textarea
+        className="border rounded w-full p-2 text-sm font-mono"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        rows={4}
+      />
+      {value !== initial && (
+        <button
+          className="mt-2 bg-blue-500 hover:bg-blue-600 text-white py-1 px-3 rounded text-sm"
+          onClick={handleSave}
+        >
+          Save
+        </button>
+      )}
+    </div>
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,8 @@
+import "../styles/globals.css";
+import type { AppProps } from "next/app";
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+
+export default MyApp;

--- a/pages/outcomes/index.tsx
+++ b/pages/outcomes/index.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from "react";
+import RecordCard from "../../components/RecordCard";
 
 interface RecordInput {
   id: string;
@@ -8,80 +9,112 @@ interface RecordInput {
 
 const OutcomesPage = () => {
   const [records, setRecords] = useState<any[]>([]);
-  const [form, setForm] = useState<RecordInput>({ id: '', type: 'text', payload: '' });
+  const [loading, setLoading] = useState(true);
+  const [form, setForm] = useState<RecordInput>({
+    id: "",
+    type: "text",
+    payload: "",
+  });
 
   const fetchRecords = async () => {
-    const res = await fetch('/api/library');
+    setLoading(true);
+    const res = await fetch("/api/library");
     const data = await res.json();
     setRecords(data);
+    setLoading(false);
   };
 
-  useEffect(() => { fetchRecords(); }, []);
+  useEffect(() => {
+    fetchRecords();
+  }, []);
 
   const addRecord = async () => {
-    await fetch('/api/library', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...form, payload: form.payload })
+    await fetch("/api/library", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...form, payload: form.payload }),
     });
-    setForm({ id: '', type: 'text', payload: '' });
+    setForm({ id: "", type: "text", payload: "" });
     fetchRecords();
   };
 
   const deleteRecord = async (id: string) => {
-    await fetch(`/api/library/${id}`, { method: 'DELETE' });
+    await fetch(`/api/library/${id}`, { method: "DELETE" });
     fetchRecords();
   };
 
   const clearAll = async () => {
-    await fetch('/api/library', { method: 'DELETE' });
+    await fetch("/api/library", { method: "DELETE" });
     fetchRecords();
   };
 
   const copyRecord = (payload: any) => {
-    navigator.clipboard.writeText(typeof payload === 'string' ? payload : JSON.stringify(payload));
+    navigator.clipboard.writeText(
+      typeof payload === "string" ? payload : JSON.stringify(payload),
+    );
   };
 
   const updateRecord = async (id: string, payload: any) => {
     await fetch(`/api/library/${id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ payload })
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ payload }),
     });
     fetchRecords();
   };
 
   return (
-    <div className="p-4 max-w-xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Outcomes</h1>
-      <div className="mb-4 flex space-x-2">
-        <input className="border p-2 flex-grow" placeholder="id" value={form.id} onChange={e => setForm({ ...form, id: e.target.value })} />
-        <select className="border p-2" value={form.type} onChange={e => setForm({ ...form, type: e.target.value })}>
+    <div className="p-4 max-w-3xl mx-auto">
+      <h1 className="text-3xl font-bold mb-6 text-center">Outcomes</h1>
+      <div className="mb-6 bg-white p-4 rounded shadow flex flex-col md:flex-row md:space-x-2 space-y-2 md:space-y-0">
+        <input
+          className="border p-2 flex-grow rounded"
+          placeholder="id"
+          value={form.id}
+          onChange={(e) => setForm({ ...form, id: e.target.value })}
+        />
+        <select
+          className="border p-2 rounded"
+          value={form.type}
+          onChange={(e) => setForm({ ...form, type: e.target.value })}
+        >
           <option value="text">text</option>
           <option value="list">list</option>
         </select>
-        <input className="border p-2 flex-grow" placeholder="payload" value={form.payload} onChange={e => setForm({ ...form, payload: e.target.value })} />
-        <button className="bg-blue-500 text-white px-3" onClick={addRecord}>Add</button>
+        <input
+          className="border p-2 flex-grow rounded"
+          placeholder="payload"
+          value={form.payload}
+          onChange={(e) => setForm({ ...form, payload: e.target.value })}
+        />
+        <button
+          className="bg-blue-500 hover:bg-blue-600 text-white px-3 rounded"
+          onClick={addRecord}
+        >
+          Add
+        </button>
       </div>
-      <button className="text-sm text-red-600 underline" onClick={clearAll}>Clear All</button>
-      <ul className="mt-4 space-y-2">
-        {records.map(r => (
-          <li key={r.id} className="border p-2 flex justify-between items-center">
-            <div className="flex-1 mr-2">
-              <div className="font-semibold">{r.id}</div>
-              <textarea
-                className="border w-full mt-1 p-1"
-                value={typeof r.payload === 'string' ? r.payload : JSON.stringify(r.payload)}
-                onChange={e => updateRecord(r.id, e.target.value)}
-              />
-            </div>
-            <div className="space-x-2">
-              <button className="text-blue-500" onClick={() => copyRecord(r.payload)}>Copy</button>
-              <button className="text-red-500" onClick={() => deleteRecord(r.id)}>Delete</button>
-            </div>
-          </li>
-        ))}
-      </ul>
+      <button
+        className="text-sm text-red-600 underline mb-4"
+        onClick={clearAll}
+      >
+        Clear All
+      </button>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <div className="grid gap-4">
+          {records.map((r) => (
+            <RecordCard
+              key={r.id}
+              record={r}
+              onCopy={copyRecord}
+              onDelete={deleteRecord}
+              onUpdate={updateRecord}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
## Summary
- add global Tailwind styles and custom _app
- create `RecordCard` component with better layout and copy/delete actions
- redesign outcomes page with responsive form and cards
- clarify README about responsive UI

## Testing
- `npm test`
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68426a17956083308bca70fbb068374e