### PR TITLE
Check DATABASE_URL and document requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ This project is a simple Next.js application written in TypeScript and styled wi
 
 The API endpoint `/api/library` supports `GET`, `POST`, and `DELETE`. Additional item routes under `/api/library/[id]` allow updating or removing records. `/api/export/[id]` can export a record as JSON, plain text, or Markdown.
 
-Set the `DATABASE_URL` environment variable to your Neon PostgreSQL connection string before running the server.
+## Environment Variables
+
+Before starting the server you must provide a PostgreSQL connection string via the `DATABASE_URL` environment variable. The application will fail to boot if this value is missing.
+
+```bash
+export DATABASE_URL=postgres://USER:PASSWORD@HOST/DATABASE
+```
 
 ### Tailwind CSS Setup
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,7 +1,13 @@
 import { Pool } from 'pg';
 
+const { DATABASE_URL } = process.env;
+
+if (!DATABASE_URL) {
+  throw new Error('DATABASE_URL environment variable is not set');
+}
+
 const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
+  connectionString: DATABASE_URL,
 });
 
 export default pool;


### PR DESCRIPTION
## Summary
- fail fast if `DATABASE_URL` is missing when creating the database connection
- document required `DATABASE_URL` environment variable in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684272f481ec833099d9dbd5fae3ecc8