### PR TITLE
Refactor API exports for Netlify

### DIFF
--- a/pages/api/docs.ts
+++ b/pages/api/docs.ts
@@ -12,7 +12,9 @@ export const getSwaggerSpec = () => createSwaggerSpec({
   },
 });
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+const handler = (req: NextApiRequest, res: NextApiResponse) => {
   const spec = getSwaggerSpec();
   res.status(200).json(spec);
-}
+};
+
+export default handler;

--- a/pages/api/export/[id].ts
+++ b/pages/api/export/[id].ts
@@ -26,7 +26,7 @@ import { toPlainText, toMarkdown } from '../../../lib/exporters';
  *         description: Not found
  */
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query as { id: string };
   const format = (req.query.format as string) || 'json';
   const record = await store.get(id);
@@ -43,4 +43,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   res.status(200).json(record);
-}
+};
+
+export default handler;

--- a/pages/api/library/[id].ts
+++ b/pages/api/library/[id].ts
@@ -51,7 +51,7 @@ import { store } from '../../../lib/dataStore';
  *         description: Not found
  */
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const { id } = req.query as { id: string };
 
   if (req.method === 'GET') {
@@ -75,4 +75,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   res.setHeader('Allow', ['GET', 'PUT', 'DELETE']);
   res.status(405).end(`Method ${req.method} Not Allowed`);
-}
+};
+
+export default handler;

--- a/pages/api/library/index.ts
+++ b/pages/api/library/index.ts
@@ -33,7 +33,7 @@ import { store, StoredRecord } from '../../../lib/dataStore';
  *       204:
  *         description: Cleared
  */
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method === 'POST') {
     const { id, type, payload } = req.body as Omit<StoredRecord, 'receivedAt'>;
     if (!id || !type) {
@@ -62,4 +62,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   res.setHeader('Allow', ['GET', 'POST', 'DELETE']);
   res.status(405).end(`Method ${req.method} Not Allowed`);
-}
+};
+
+export default handler;


### PR DESCRIPTION
## Summary
- export all API handlers as constants before default export

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684277ca7af883308bb4a006eb1160d4