### PR TITLE
Enforce DATABASE_URL presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The API endpoint `/api/library` supports `GET`, `POST`, and `DELETE`. Additional
 
 ## Environment Variables
 
-The API uses PostgreSQL when the `DATABASE_URL` environment variable is provided. If this variable is omitted **or contains anything other than a valid PostgreSQL connection string**, requests are served from an in-memory store instead of a database.
+The API requires the `DATABASE_URL` environment variable to be set to a valid PostgreSQL connection string. The application will throw an error on startup if this variable is missing or malformed.
 
 
 ```bash

--- a/lib/dataStore.ts
+++ b/lib/dataStore.ts
@@ -89,58 +89,6 @@ class DataStore {
   }
 }
 
-class MemoryStore {
-  private records = new Map<string, StoredRecord>();
-
-  async add(record: Omit<StoredRecord, 'receivedAt' | 'updatedAt'>): Promise<StoredRecord> {
-    if (this.records.has(record.id)) {
-      const err: any = new Error('duplicate');
-      err.code = '23505';
-      throw err;
-    }
-    const receivedAt = Date.now();
-    const entry = { ...record, receivedAt };
-    this.records.set(record.id, entry);
-    return entry;
-  }
-
-  async list(): Promise<StoredRecord[]> {
-    return Array.from(this.records.values());
-  }
-
-  async get(id: string): Promise<StoredRecord | null> {
-    return this.records.get(id) || null;
-  }
-
-  async update(id: string, update: Partial<Omit<StoredRecord, 'id' | 'receivedAt'>>): Promise<StoredRecord | null> {
-    const existing = await this.get(id);
-    if (!existing) return null;
-    const payload = update.payload !== undefined ? update.payload : existing.payload;
-    const type = update.type || existing.type;
-    const updatedAt = Date.now();
-    const updated = { ...existing, type, payload, updatedAt };
-    this.records.set(id, updated);
-    return updated;
-  }
-
-  async remove(id: string): Promise<StoredRecord | null> {
-    const existing = await this.get(id);
-    if (!existing) return null;
-    this.records.delete(id);
-    return existing;
-  }
-
-  async clear(): Promise<void> {
-    this.records.clear();
-  }
-}
-
-let store: DataStore | MemoryStore;
-
-if (pool) {
-  store = new DataStore(pool);
-} else {
-  store = new MemoryStore();
-}
+const store = new DataStore(pool);
 
 export { store };

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -2,15 +2,10 @@ import { Pool } from 'pg';
 
 const { DATABASE_URL } = process.env;
 
-let pool: Pool | null = null;
-
-if (DATABASE_URL && DATABASE_URL.startsWith('postgres')) {
-  pool = new Pool({
-    connectionString: DATABASE_URL,
-  });
-} else {
-  // eslint-disable-next-line no-console
-  console.warn('DATABASE_URL missing or invalid; falling back to in-memory store');
+if (!DATABASE_URL || !DATABASE_URL.startsWith('postgres')) {
+  throw new Error('DATABASE_URL is missing or invalid');
 }
+
+const pool = new Pool({ connectionString: DATABASE_URL });
 
 export default pool;


### PR DESCRIPTION
## Summary
- remove fallback logic and require a valid `DATABASE_URL`
- drop in-memory store from dataStore
- document mandatory `DATABASE_URL`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68438eabdd68833086b9f90d0dc8275f