### PR TITLE
Support Netlify managed database env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,16 @@ The API endpoint `/api/library` supports `GET`, `POST`, and `DELETE`. Additional
 
 ## Environment Variables
 
-The API requires the `DATABASE_URL` environment variable to be set to a valid PostgreSQL connection string. The application will throw an error on startup if this variable is missing or malformed.
-
+The API requires a PostgreSQL connection string. Locally you can define
+`DATABASE_URL`:
 
 ```bash
 export DATABASE_URL=postgres://USER:PASSWORD@HOST/DATABASE
 ```
+
+When deployed on Netlify using the database add-on, the connection string is
+provided via `NETLIFY_DATABASE_URL` (and `NETLIFY_DATABASE_URL_UNPOOLED` for
+serverless drivers), so no additional configuration is necessary.
 
 ### Tailwind CSS Setup
 
@@ -56,11 +60,17 @@ To quickly see the UI with some content, run:
 npm run seed
 ```
 
-This command populates the `records` table with a few example entries using the same connection string defined in `DATABASE_URL`.
+This command populates the `records` table with a few example entries using the
+same connection string configured for the application.
 
 ### Deploying to Netlify
 
 1. Push this repo to a Git host and create a new site on Netlify.
-2. In **Site settings → Environment variables**, set `DATABASE_URL` to your PostgreSQL connection string.
-3. Netlify runs `npm run build`. Next.js outputs a fully static site to the `out` directory because `output: 'export'` is set in `next.config.js`.
-4. API endpoints are served from Netlify Functions located in `netlify/functions` as configured in `netlify.toml`.
+2. If you are not using Netlify's database add-on, define `DATABASE_URL` in
+   **Site settings → Environment variables**. When the add-on is enabled, the
+   variables `NETLIFY_DATABASE_URL` and `NETLIFY_DATABASE_URL_UNPOOLED` are set
+   automatically.
+3. Netlify runs `npm run build`. Next.js outputs a fully static site to the
+   `out` directory because `output: 'export'` is set in `next.config.js`.
+4. API endpoints are served from Netlify Functions located in `netlify/functions`
+   as configured in `netlify.toml`.

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,11 +1,18 @@
 import { Pool } from 'pg';
 
-const { DATABASE_URL } = process.env;
+const {
+  DATABASE_URL,
+  NETLIFY_DATABASE_URL,
+  NETLIFY_DATABASE_URL_UNPOOLED,
+} = process.env;
 
-if (!DATABASE_URL || !DATABASE_URL.startsWith('postgres')) {
-  throw new Error('DATABASE_URL is missing or invalid');
+const connectionString =
+  DATABASE_URL || NETLIFY_DATABASE_URL || NETLIFY_DATABASE_URL_UNPOOLED;
+
+if (!connectionString || !connectionString.startsWith('postgres')) {
+  throw new Error('Database connection string is missing or invalid');
 }
 
-const pool = new Pool({ connectionString: DATABASE_URL });
+const pool = new Pool({ connectionString });
 
 export default pool;

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -1,7 +1,16 @@
 const { Pool } = require('pg');
 
+const {
+  DATABASE_URL,
+  NETLIFY_DATABASE_URL,
+  NETLIFY_DATABASE_URL_UNPOOLED,
+} = process.env;
+
+const connectionString =
+  DATABASE_URL || NETLIFY_DATABASE_URL || NETLIFY_DATABASE_URL_UNPOOLED;
+
 const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
+  connectionString,
 });
 
 async function seed() {


### PR DESCRIPTION
## Summary
- let the database connection fall back to `NETLIFY_DATABASE_URL` or `NETLIFY_DATABASE_URL_UNPOOLED`
- update seed script to use those variables
- document Netlify DB integration in README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68449e88d4dc8330a0e9f61e98ce2ef4