### PR TITLE
Add ChatGPT plugin assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,16 @@ same environment-based connection as the application.
    `out` directory because `output: 'export'` is set in `next.config.js`.
 4. API endpoints are served from Netlify Functions located in `netlify/functions`
    as configured in `netlify.toml`.
+
+### Enabling ChatGPT Actions
+
+The `public/openapi.yaml` file contains the OpenAPI definition for the API. A plugin manifest is provided at `public/.well-known/ai-plugin.json` which references this schema.
+
+Deploy the contents of the `public` folder so they are reachable at your domain root. For the hosted demo this repository refers to, they are available at:
+
+```
+https://llmtalks.netlify.app/openapi.yaml
+https://llmtalks.netlify.app/.well-known/ai-plugin.json
+```
+
+These files allow ChatGPT or a custom GPT to perform real actions through the Data Library API.

--- a/public/.well-known/ai-plugin.json
+++ b/public/.well-known/ai-plugin.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "v1",
+  "name_for_model": "data_library",
+  "name_for_human": "Data Library Assistant",
+  "description_for_model": "Manage records via the Data Library API",
+  "description_for_human": "Handles CRUD and export operations through the Data Library API",
+  "api": {
+    "type": "openapi",
+    "url": "https://llmtalks.netlify.app/openapi.yaml"
+  },
+  "auth": {
+    "type": "none"
+  },
+  "logo_url": "https://llmtalks.netlify.app/logo.png",
+  "contact_email": "support@llmtalks.netlify.app",
+  "legal_info_url": "https://llmtalks.netlify.app/legal"
+}

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -1,0 +1,108 @@
+openapi: 3.0.0
+info:
+  title: Data Library API
+  version: 1.0.0
+servers:
+  - url: https://llmtalks.netlify.app
+paths:
+  /api/export/{id}:
+    get:
+      description: Export a record in various formats.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: format
+          required: false
+          schema:
+            type: string
+            enum:
+              - json
+              - text
+              - markdown
+      responses:
+        '200':
+          description: Exported data
+        '404':
+          description: Not found
+  /api/library/{id}:
+    get:
+      description: Get a single record.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Stored record
+        '404':
+          description: Not found
+    put:
+      description: Update a record.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Updated record
+        '404':
+          description: Not found
+    delete:
+      description: Delete a record.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Deleted
+        '404':
+          description: Not found
+  /api/library:
+    get:
+      description: List all stored records.
+      responses:
+        '200':
+          description: Array of stored records
+    post:
+      description: Store a new record. Accepts JSON payload.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                type:
+                  type: string
+                payload:
+                  type: object
+      responses:
+        '200':
+          description: Stored record
+    delete:
+      description: Remove all records.
+      responses:
+        '204':
+          description: Cleared
+components: {}
+tags: []
+


### PR DESCRIPTION
## Summary
- add OpenAPI schema and plugin manifest files under `public/`
- document how to use these files with ChatGPT
- point plugin URLs to the hosted demo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68466e66c9a48330bec7795a2d66e2c5